### PR TITLE
Update batteur.c. Don't use sample_rate from LV2_Options. 

### DIFF
--- a/lv2/batteur.c
+++ b/lv2/batteur.c
@@ -378,7 +378,7 @@ instantiate(const LV2_Descriptor* descriptor,
                     lv2_log_warning(&self->logger, "Got a sample rate but the type was wrong\n");
                     continue;
                 }
-                self->sample_rate = *(float*)opt->value;
+                //self->sample_rate = *(float*)opt->value;
             } else if (!self->expect_nominal_block_length && opt->key == self->max_block_length_uri) {
                 if (opt->type != self->atom_int_uri) {
                     lv2_log_warning(&self->logger, "Got a max block size but the type was wrong\n");
@@ -730,7 +730,7 @@ lv2_set_options(LV2_Handle instance, const LV2_Options_Option* options)
                 lv2_log_warning(&self->logger, "Got a sample rate but the type was wrong\n");
                 continue;
             }
-            self->sample_rate = *(float*)opt->value;
+            //self->sample_rate = *(float*)opt->value;
             batteur_set_sample_rate(self->player, self->sample_rate);
         } else if (!self->expect_nominal_block_length && opt->key == self->max_block_length_uri) {
             if (opt->type != self->atom_int_uri) {


### PR DESCRIPTION
Otherwise short click and double click is not detected after mod-host commit.

//self->sample_rate = *(float*)opt->value;

Looks now that mod-host uses atom_float_uri, sample_rate gets a wrong value. https://github.com/moddevices/mod-host/commit/0d16999a36c9e8bdee2138779bfca881ae71ca6f